### PR TITLE
Remove comment token (was being ignored), simplify action

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ Only nodejs (JavaScript, TypeScript) is currently supported, with plans for Java
         -Dsonar.organization=bcgov-sonarcloud
         -Dsonar.projectKey=bcgov_${{ github.repository }}
 
-    # Sonar comment token
-    # Providing this will enable SonarCloud to comment on Pull Requests
-    # $${{ secrets.GITHUB }} or a personal access token can be used
-    sonar_comment_token: ${{ secrets.GITHUB_TOKEN }}
-
     # Sonar project token
     # Available from sonarcloud.io or your organization administrator
     # BCGov i.e. https://github.com/BCDevOps/devops-requests/issues/new/choose
@@ -127,7 +122,7 @@ jobs:
 
 # Example, Matrix / Multiple Directories with Sonar Cloud
 
-Unit test and analyze projects in multiple directories in parallel.  This time `repository` and `sonar_comment_token` are provided.  Please note how secrets must be passed in to composite Actions using the secrets[matrix.variable] syntax.
+Unit test and analyze projects in multiple directories in parallel.  This time `repository` is provided.  Please note how secrets must be passed in to composite Actions using the secrets[matrix.variable] syntax.
 
 ```yaml
 jobs:
@@ -155,7 +150,6 @@ jobs:
             -Dsonar.exclusions=**/coverage/**,**/node_modules/**
             -Dsonar.organization=bcgov-nr
             -Dsonar.projectKey=bcgov-nr_action-test-and-analyse_${{ matrix.dir }}
-          sonar_comment_token: ${{ secrets.GITHUB_TOKEN }}
           sonar_project_token: ${{ secrets[matrix.token] }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,6 @@ inputs:
     default: |
       -Dsonar.organization=bcgov-sonarcloud
       -Dsonar.projectKey=bcgov_${{ github.repository }}
-  sonar_comment_token:
-    description: Token for pull request comments, usually secrets.GITHUB_TOKEN
   sonar_project_token:
     description: Sonar token, provide unpopulated token for pre-setup (will skip)
 
@@ -36,18 +34,26 @@ inputs:
 runs:
   using: composite
   steps:
-    # Shallow clone is faster, but SonarCloud requires a full clone
-    - uses: actions/checkout@v3
-      if: (! inputs.sonar_project_token)
-      with:
-        repository: ${{ inputs.repository }}
+    # Process inputs
+    - id: inputs
+      shell: bash
+      run: |
+        # Process inputs
+        if [ -z ${{ inputs.sonar_project_token }} ]; then
+          shallowClone=1
+          sonarCheck=true
+        else
+          shallowClone=0 >> $GITHUB_OUTPUT
+          sonarCheck=false >> $GITHUB_OUTPUT
+        fi
 
-    # Shallow clone is faster, but can't be used with SonarCloud
+        echo shallowClone=${shallowClone} >> $GITHUB_OUTPUT
+        echo sonarCheck=${sonarCheck} >> $GITHUB_OUTPUT
+
+    # SonarCloud uses shallow clone (fetch-depth=0), which is a bit slower/heavier
     - uses: actions/checkout@v3
-      if: inputs.sonar_project_token
       with:
-        # Disable shallow clone for SonarCloud analysis
-        fetch-depth: 0
+        fetch-depth: steps.inputs.outputs.shallowClone
         repository: ${{ inputs.repository }}
 
     # Setup node and cache dir
@@ -72,30 +78,15 @@ runs:
 
     ### Optional SonarCloud
 
-    # If sonar_project_token and sonar_comment_token, then run with comments
+    # If sonar_project_token, then run with comments
     - name: SonarCloud Scan
-      if: inputs.sonar_project_token && inputs.sonar_comment_token
-      uses: SonarSource/sonarcloud-github-action@v1.8
-      env:
-        GITHUB_TOKEN: ${{ inputs.sonar_comment_token }}
-        SONAR_TOKEN: ${{ inputs.sonar_project_token }}
-      with:
-        projectBaseDir: ${{ inputs.dir }}
-        args: >
-          -Dsonar.pullrequest.github.summary_comment=true
-          ${{ inputs.sonar_args }}
-
-    # If sonar_project_token and not sonar_comment_token, then run without comments
-    - name: SonarCloud Scan
-      if: inputs.sonar_project_token && ! inputs.sonar_comment_token
+      if: inputs.sonar_project_token
       uses: SonarSource/sonarcloud-github-action@v1.8
       env:
         SONAR_TOKEN: ${{ inputs.sonar_project_token }}
       with:
         projectBaseDir: ${{ inputs.dir }}
-        args: >
-          -Dsonar.pullrequest.github.summary_comment=false
-          ${{ inputs.sonar_args }}
+        args: ${{ inputs.sonar_args }}
 
     # Fix - Docker takes ownership of files, causing a cleanup fail
     - shell: bash


### PR DESCRIPTION
SonarCloud.io hasn't been respecting our argument/flag for PR commenting.  Not a big deal, since it can be configured through their website, free of charge.  Useless functionality being removed, but could be revisited.