### PR TITLE
fix: dial down sonar action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ runs:
 
     # If sonar_token
     - if: inputs.sonar_token && steps.diff.outputs.triggered == 'true'
-      uses: SonarSource/sonarcloud-github-action@v2.1.1
+      uses: SonarSource/sonarcloud-github-action@v2.0.2
       env:
         SONAR_TOKEN: ${{ inputs.sonar_token }}
       with:


### PR DESCRIPTION
v2.1.0 and v2.1.1 have been causing breaks.  This steps down versions.  Hopefully Sonar will fix this, but it's been almost five months.

https://github.com/SonarSource/sonarcloud-github-action/releases