### PR TITLE
fix(ci): pin test repository refs to stable commits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,7 @@ jobs:
             dep_scan: warn
             test_command: echo "Good enough for testing knip!"
             repository: bcgov/nr-waste-plus
+            branch: 326778f5ae22129bd490795493c4e53e4f3de5f9 # Pin to stable commit
     steps:
       - id: action
         uses: bcgov/action-test-and-analyse@temporary-branch
@@ -109,6 +110,7 @@ jobs:
           dir: ${{ matrix.dir }}
           node_version: ${{ needs.init.outputs.node_version }}
           repository: ${{ matrix.repository }}
+          branch: ${{ matrix.branch || 'a5b623e6167d91e2bf1e2332fa24495887d83d5e' }} # Default to stable quickstart commit
           triggers: ${{ matrix.triggers }}
           dep_scan: ${{ matrix.dep_scan }}
 


### PR DESCRIPTION
## Summary
Upstream breakage in `bcgov/quickstart-openshift` (merged broken lockfile on April 7th) is causing all CI runs to fail during `npm ci`.

This PR pins the test repositories to known good commits to protect this action's CI from upstream instability.

## Changes
- Pinned `bcgov/quickstart-openshift` to `a5b623e6` (April 2nd)
- Pinned `bcgov/nr-waste-plus` to `326778f5`
- Added `branch` input to the action call in `tests.yml`